### PR TITLE
Adds 'info' to nowPlaying

### DIFF
--- a/lib/sonos/endpoint/a_v_transport.rb
+++ b/lib/sonos/endpoint/a_v_transport.rb
@@ -23,6 +23,7 @@ module Sonos::Endpoint::AVTransport
       title: doc.xpath('//dc:title').inner_text,
       artist: doc.xpath('//dc:creator').inner_text,
       album: doc.xpath('//upnp:album').inner_text,
+      info: doc.xpath('//r:streamContent').inner_text,
       queue_position: body[:track],
       track_duration: body[:track_duration],
       current_position: body[:rel_time],


### PR DESCRIPTION
Adds the 'information' field used by streaming radio to the now_playing info

![image](https://f.cloud.github.com/assets/471651/294367/78af1682-93e5-11e2-9e14-5a049d79b5a3.png)
