### PR TITLE
added party mode support

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -59,6 +59,14 @@ speaker.save_queue 'Jams'
 speaker.clear_queue
 ```
 
+Or go into what the official control from Sonos, Inc. calls "Party
+Mode": put all speakers into a single group
+
+``` ruby
+system.party_mode
+system.party_over
+```
+
 ### Topology
 
 `Sonos.discover` finds the first speaker it can. We can get all of the Sonos devices (including Bridges, etc) by calling `Sonos.system.devices`. To get the groups, call `Sonos.system.groups`.


### PR DESCRIPTION
The tricky part here is fixing up `Sonos::System#groups` when entering/exiting party mode.  I gutted the constructor and moved all the logic into `Sonos::System#rescan`, and just have the constructor call into that.  As before, if you pass it an existing topology object, it won't redo multicast discovery.  It does still call out to all the existing speakers to get their status, though.

I'm not entirely sure what the right approach is to keeping `Sonos::System#groups` in sync (cache invalidation is hard!).  The three options look like...
1. Rework the whole way groups are handled & get rid of the local cache.  That means every time you look at a group, Ruby has to call out to every speaker.  Yick.
2. Keep the existing framework, but create some notion of a TTL.  If it's been more than N seconds since the last scan and someone wants to do something with `Sonos::System#groups`, do a rescan under the covers.
3. Keep the existing framework, document the inconsistency in the groups, and encourage the developer to do frequent manual rescans when they're doing something around a group.

(2) feels like it's the nicest to the developer, but also requires the most work.
