### PR TITLE
Reuse devices created from TopologyNode

### DIFF
--- a/lib/sonos/topology_node.rb
+++ b/lib/sonos/topology_node.rb
@@ -15,7 +15,7 @@ module Sonos
     end
 
     def device
-      @device || Device::Base.detect(ip)
+      @device ||= Device::Base.detect(ip)
     end
   end
 end


### PR DESCRIPTION
This fixes a bug where you can't control speakers via groups:

```
2.0.0p247 :001 > require "sonos"
 => true 
2.0.0p247 :002 > system = Sonos::System.new
 => #<Sonos::System:0x007fd325984518 [...]> 
2.0.0p247 :003 > system.groups.first.pause
NoMethodError: undefined method `ip' for nil:NilClass
    from [...]/lib/sonos/endpoint/a_v_transport.rb:131:in `transport_client'
    from [...]/lib/sonos/endpoint/a_v_transport.rb:137:in `send_transport_message'
    from [...]/lib/sonos/endpoint/a_v_transport.rb:41:in `pause'
    from [...]/lib/sonos/group.rb:36:in `block (2 levels) in <class:Group>'
    from (irb):3
    from [...]/.rvm/rubies/ruby-2.0.0-p247/bin/irb:16:in `<main>'
```

The nil object that #ip is being called on is self.group_master. Although group_master is set for each speaker in System#rescan, because of this bug, those speaker objects aren't the same as the ones that are in the groups.

```
2.0.0p247 :004 > system.speakers.count {|s| s.group_master.nil?}
 => 0 
2.0.0p247 :005 > system.groups.first.speakers.count {|s| s.group_master.nil?}
 => 2
```
