### PR TITLE
Add get_player_state method to retrieve the state/status/speed of the speaker

### DIFF
--- a/lib/sonos/endpoint/a_v_transport.rb
+++ b/lib/sonos/endpoint/a_v_transport.rb
@@ -36,6 +36,18 @@ module Sonos::Endpoint::AVTransport
     !now_playing.nil?
   end
 
+  # Get information about the state the player is in.
+  def get_player_state
+    response = send_transport_message('GetTransportInfo')
+    body = response.body[:get_transport_info_response]
+
+    {
+      status: body[:current_transport_status],
+      state:  body[:current_transport_state],
+      speed:  body[:current_speed],
+    }
+  end
+
   # Pause the currently playing track.
   def pause
     send_transport_message('Pause')


### PR DESCRIPTION
Currently there is no reliable way to find out if the speaker is playing or paused/stopped.
SoCo uses the `GetTransportInfo` call which I've implemented as `get_player_state`:

```
irb(main):004:0> state = speaker.get_player_state
D, [2014-01-20T20:51:42.982358 #29285] DEBUG -- : HTTPI POST request to 192.168.178.113 (httpclient)
=> {:status=>"OK", :state=>"PAUSED_PLAYBACK", :speed=>"1"}
```
