### PR TITLE
Add method to queue spotify tracks.

### DIFF
--- a/lib/sonos/endpoint/a_v_transport.rb
+++ b/lib/sonos/endpoint/a_v_transport.rb
@@ -86,15 +86,59 @@ module Sonos::Endpoint::AVTransport
 
   # Adds a track to the queue
   # @param[String] uri Uri of track
+  # @param[String] didl Stanza of DIDL-Lite metadata (generally created by #add_spotify_to_queue)
   # @return[Integer] Queue position of the added track
-  def add_to_queue(uri)
-    response = send_transport_message('AddURIToQueue', "<EnqueuedURI>#{uri}</EnqueuedURI><EnqueuedURIMetaData></EnqueuedURIMetaData><DesiredFirstTrackNumberEnqueued>0</DesiredFirstTrackNumberEnqueued><EnqueueAsNext>1</EnqueueAsNext>")
+  def add_to_queue(uri, didl = '')
+    response = send_transport_message('AddURIToQueue', "<EnqueuedURI>#{uri}</EnqueuedURI><EnqueuedURIMetaData>#{didl}</EnqueuedURIMetaData><DesiredFirstTrackNumberEnqueued>0</DesiredFirstTrackNumberEnqueued><EnqueueAsNext>1</EnqueueAsNext>")
     # TODO yeah, this error handling is a bit soft. For consistency's sake :)
     pos = response.xpath('.//FirstTrackNumberEnqueued').text
     if pos.length != 0
       pos.to_i
     end
   end
+
+  # Adds a Spotify track to the queue along with extra data for better metadata retrieval
+  # @param[Hash] opts Various options (id, user, region and type)
+  # @return[Integer] Queue position of the added track(s)
+  def add_spotify_to_queue(opts = {})
+    opts = {
+      :id     => '',
+      :user   => nil,
+      :region => nil,
+      :type   => 'track'
+    }.merge(opts)
+
+    # Basic validation of the accepted types; playlists need an associated user
+    # and the toplist (for tracks and albums) need to specify a region.
+    return nil if opts[:type] == 'playlist' and opts[:user].nil?
+    return nil if opts[:type] =~ /toplist_tracks/ and opts[:region].nil?
+
+    # In order for the player to retrieve track duration, artist, album etc
+    # we need to pass it some metadata ourselves.
+    didl_metadata = "&lt;DIDL-Lite xmlns:dc=&quot;http://purl.org/dc/elements/1.1/&quot; xmlns:upnp=&quot;urn:schemas-upnp-org:metadata-1-0/upnp/&quot; xmlns:r=&quot;urn:schemas-rinconnetworks-com:metadata-1-0/&quot; xmlns=&quot;urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/&quot;&gt;&lt;item id=&quot;#{rand(10000000..99999999)}spotify%3a#{opts[:type]}%3a#{opts[:id]}&quot; restricted=&quot;true&quot;&gt;&lt;dc:title&gt;&lt;/dc:title&gt;&lt;upnp:class&gt;object.item.audioItem.musicTrack&lt;/upnp:class&gt;&lt;desc id=&quot;cdudn&quot; nameSpace=&quot;urn:schemas-rinconnetworks-com:metadata-1-0/&quot;&gt;SA_RINCON2311_X_#Svc2311-0-Token&lt;/desc&gt;&lt;/item&gt;&lt;/DIDL-Lite&gt;"
+
+    r_id = rand(10000000..99999999)
+
+    case opts[:type]
+    when /playlist/
+      uri = "x-rincon-cpcontainer:#{r_id}spotify%3auser%3a#{opts[:user]}%3aplaylist%3a#{opts[:id]}"
+    when /toplist_(tracks)/
+      subtype = opts[:type].sub('toplist_', '') # only 'tracks' are supported right now by Sonos.
+      uri = "x-rincon-cpcontainer:#{r_id}toplist%2f#{subtype}%2fregion%2f#{opts[:region]}"
+    when /album/
+      uri = "x-rincon-cpcontainer:#{r_id}spotify%3aalbum%3a#{opts[:id]}"
+    when /artist/
+      uri = "x-rincon-cpcontainer:#{r_id}tophits%3aspotify%3aartist%3a#{opts[:id]}"
+    when /starred/
+      uri = "x-rincon-cpcontainer:#{r_id}starred"
+    when /track/
+      uri = "x-sonos-spotify:spotify%3a#{opts[:type]}%3a#{opts[:id]}"
+    else
+      return nil
+    end
+
+    add_to_queue(uri, didl_metadata)
+   end
 
   # Removes a track from the queue
   # @param[String] object_id Track's queue ID


### PR DESCRIPTION
While it was already possible to add the spotify uri with #add_to_queue,
the metadata (artist, album, etc) would not be looked up by the Sonos device.
In order for this to be done we need to pass it a bit of DIDL metadata.

First let's add a spotify song in the "old" way, notice that the call to `queue` doesn't return any metadata:

```
irb(main):008:0> speaker.add_to_queue('x-sonos-spotify:spotify%3atrack%3a2CwulIyrmEYwbUWzcEVIhR?sid=9&amp;flags=32')
D, [2014-01-22T19:28:09.673956 #17154] DEBUG -- : HTTPI POST request to 192.168.178.113 (httpclient)
=> 1
irb(main):009:0> speaker.queue
D, [2014-01-22T19:28:11.683893 #17154] DEBUG -- : HTTPI POST request to 192.168.178.113 (httpclient)
=> {:total=>1, :items=>[{:queue_id=>"Q:0/1", :title=>"x-sonos-spotify:spotify:track:2CwulIyrmEYwbUWzcEVIhR?sid=9&flags=32", :artist=>"", :album=>"", :album_art=>"http://192.168.178.113:1400/getaa?s=1&u=x-sonos-spotify%3aspotify%253atrack%253a2CwulIyrmEYwbUWzcEVIhR%3fsid%3d9%26flags%3d32", :duration=>nil, :id=>"x-sonos-spotify:spotify%3atrack%3a2CwulIyrmEYwbUWzcEVIhR?sid=9&flags=32"}]}
irb(main):010:0> 
```

Now let's add the same track with the new method `add_spotify_to_queue`:

```
irb(main):005:0> speaker.add_spotify_to_queue('2CwulIyrmEYwbUWzcEVIhR')
D, [2014-01-22T19:26:54.857300 #17154] DEBUG -- : HTTPI POST request to 192.168.178.113 (httpclient)
=> 1
irb(main):006:0> speaker.queue
D, [2014-01-22T19:26:58.109215 #17154] DEBUG -- : HTTPI POST request to 192.168.178.113 (httpclient)
=> {:total=>1, :items=>[{:queue_id=>"Q:0/1", :title=>"Shotgun", :artist=>"Anton Zaslavski", :album=>"Shotgun", :album_art=>"http://192.168.178.113:1400/getaa?s=1&u=x-sonos-spotify%3aspotify%253atrack%253a2CwulIyrmEYwbUWzcEVIhR%3fsid%3d9%26flags%3d32", :duration=>"0:04:28", :id=>"x-sonos-spotify:spotify%3atrack%3a2CwulIyrmEYwbUWzcEVIhR?sid=9&flags=32"}]}
irb(main):007:0> 
```
