### PR TITLE
Individual speakers are zones too

### DIFF
--- a/lib/sonos/system.rb
+++ b/lib/sonos/system.rb
@@ -107,7 +107,7 @@ module Sonos
           nodes << node unless node.uuid == master.uuid
         end
 
-        # Skip this group if there are no nodes or master
+        # Skip this group if there is no master
         next if master.nil?
 
         # Add the group


### PR DESCRIPTION
Sam,

I noticed the Groups feature was limited to zones with more than one speaker in it.  This PR updates the gem's behavior to mirror the behavior of a Sonos controller which displays a Zone as a collection containing one or more speakers.  Previously, it was almost impossible to identify zones that contained only one speaker.

Regards,
