### PR TITLE
Fixed bug where the speaker saved to group would not get the master_spea...

### DIFF
--- a/lib/sonos/group.rb
+++ b/lib/sonos/group.rb
@@ -3,7 +3,7 @@ module Sonos
   # play the same music in sync.
   class Group
     # The master speaker in the group
-    attr_reader :master_speaker
+    attr_accessor :master_speaker
 
     # All other speakers in the group
     attr_reader :slave_speakers

--- a/lib/sonos/system.rb
+++ b/lib/sonos/system.rb
@@ -71,13 +71,16 @@ module Sonos
       @topology = topology
       @groups = []
       @devices = @topology.collect(&:device)
-
+      
       construct_groups
 
       speakers.each do |speaker|
         speaker.group_master = speaker
         @groups.each do |group|
-          speaker.group_master = group.master_speaker if group.master_speaker.uid == speaker.uid
+          if group.master_speaker.uid == speaker.uid
+            speaker.group_master = speaker
+            group.master_speaker = speaker
+          end
           group.slave_speakers.each do |slave|
             speaker.group_master = group.master_speaker if slave.uid == speaker.uid
           end


### PR DESCRIPTION
Sam,

This PR fixes an issue with my one of my previous contributions.  The speaker.group_master was not updating when the construct_groups method was called.  As a result, calling system.groups.first.play was not routing properly to the groups master, resulting in a nil object error.  This update makes sure all speakers and groups get updated with the proper group_master and master_speaker attributes.

Regards,
