### PR TITLE
Add support for creating and separating a stereo pair.

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -118,7 +118,6 @@ You can also run `sonos pause_all` to pause all your Sonos groups.
 If we are implementing everything the official Sonos Controller does, here's some more stuff:
 
 * Set zone name and icon
-* Create stero pair
 * Support for SUB
 * Support for DOCK
 * Support for CONNECT:AMP (not sure if this is any different from CONNECT)

--- a/lib/sonos/endpoint/device.rb
+++ b/lib/sonos/endpoint/device.rb
@@ -16,6 +16,20 @@ module Sonos::Endpoint::Device
     parse_response send_device_message('SetLEDState', enabled ? 'On' : 'Off')
   end
 
+  # Create a stereo pair of two speakers.
+  # This does not take into account which type of players support bonding.
+  # Currently only S1/S3 (play:1/play:3) support this but future players may
+  # gain this abbility too.
+  # @param left [String] uid of the left speaker
+  # @param right [String] uid of the right speaker
+  def create_pair(left, right)
+    parse_response = send_bonding_message('AddBondedZones', "#{left}:LF,LF;#{right}:RF,RF")
+  end
+
+  def separate_pair
+    parse_response = send_bonding_message('RemoveBondedZones', '')
+  end
+
 private
 
   def device_client
@@ -26,6 +40,12 @@ private
     action = "#{DEVICE_XMLNS}##{name}"
     attribute = name.sub('Set', '')
     message = %Q{<u:#{name} xmlns:u="#{DEVICE_XMLNS}"><Desired#{attribute}>#{value}</Desired#{attribute}>}
+    device_client.call(name, soap_action: action, message: message)
+  end
+
+  def send_bonding_message(name, value)
+    action = "#{DEVICE_XMLNS}##{name}"
+    message = %Q{<u:#{name} xmlns:u="#{DEVICE_XMLNS}"><ChannelMapSet>#{value}</ChannelMapSet></u:#{name}>}
     device_client.call(name, soap_action: action, message: message)
   end
 end


### PR DESCRIPTION
I decided to use the devices 'uid' as arguments to the `create_pair` method to keep the method simple. I could rework it to accept a `Sonos::Device::Speaker` if desired but that would require some additional checks in the method..

```
system = Sonos::System.new
left = system.speakers[0]
right = system.speakers[1]
left.create_pair(left.uid.sub('uuid:', ''),
                         right.uid.sub('uuid:', ''))
```

and to unpair:

```
left.separate_pair
```
