### PR TITLE
Sync Readme, these features have already been implemented

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -98,9 +98,6 @@ You can also run `sonos pause_all` to pause all your Sonos groups.
 * Pause all (there is no play all in the controller, we could loop through and do it though)
 * Party Mode
 * Line-in
-* Toggle cross fade
-* Toggle shuffle
-* Set repeat mode
 * Search music library
 * Browse music library
 * Skip to song in queue


### PR DESCRIPTION
Party mode is also implemented but there is this call:
https://github.com/soffes/sonos/blob/master/lib/sonos/system.rb#L40 which seems odd. Removing it does create a party but only for the first two speakers and it throws a `UPnPError`; to be investigated.

For now, the three working items can be removed from the ToDo list.
