### PR TITLE
Add a way to set the sleep timer.

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -105,7 +105,6 @@ You can also run `sonos pause_all` to pause all your Sonos groups.
 * Browse music library
 * Skip to song in queue
 * Alarm clock
-* Sleep timer
 * Pandora doesn't use the Queue. I bet things are all jacked up.
 * CONNECT (and possibly PLAY:5) line in settings
     * Source name

--- a/lib/sonos/endpoint/a_v_transport.rb
+++ b/lib/sonos/endpoint/a_v_transport.rb
@@ -77,7 +77,7 @@ module Sonos::Endpoint::AVTransport
   def previous
     parse_response send_transport_message('Previous')
   end
-  
+
   def line_in(speaker)
     set_av_transport_uri('x-rincon-stream:' + speaker.uid.sub('uuid:', ''))
   end
@@ -178,6 +178,19 @@ module Sonos::Endpoint::AVTransport
   # Trying to call this on a stereo pair slave will fail.
   def ungroup
     parse_response send_transport_message('BecomeCoordinatorOfStandaloneGroup')
+  end
+
+  # Set a sleep timer up to 23:59:59
+  # E.g. '00:11:00' for 11 minutes.
+  # @param duration [String] Duration of timer or nil to clear.
+  def set_sleep_timer(duration)
+    if duration.nil?
+      duration = ''
+    elsif duration.gsub(':', '').to_i > 235959
+      duration = '23:59:59'
+    end
+
+    parse_response send_transport_message('ConfigureSleepTimer', "<NewSleepTimerDuration>#{duration}</NewSleepTimerDuration>")
   end
 
   private


### PR DESCRIPTION
It turns out the system doesn't allow for setting a timer >= 24 hours, so there's a little validation built into `#set_sleep_timer` which caps anything exceeding the maximum to 23:59:59.
