### PR TITLE
added facility to look up speaker by uid and name

### DIFF
--- a/lib/sonos/system.rb
+++ b/lib/sonos/system.rb
@@ -64,6 +64,21 @@ module Sonos
       speakers[0]
     end
 
+    def find_speaker_by_name(name)
+      speakers.each do |speaker|
+        return speaker if(speaker.name == name)
+      end
+      return nil
+    end
+
+    def find_speaker_by_uid(uid)
+      uid = "uuid:" + uid unless uid[0,5] == "uuid:"
+      speakers.each do |speaker|
+        return speaker if(speaker.uid == uid)
+      end
+      return nil
+    end
+
     # Party's over :(
     def party_over
       groups.each { |g| g.disband }


### PR DESCRIPTION
I've been using this code for a while on a local fork and just realized I never submitted a PR for it.  With this patch, you do things like:

if you know the name:

`sonos = Sonos::System.new`
`living_room = sonos.find_speaker_by_name("Living Room")`

if you happen to know the uid:

`sonos = Sonos::System.new`
`living_room = sonos.find_speaker_by_uid("RINCON_1234EEFEE12341400")`