### PR TITLE
Fixes DIDL metadata for Spotify

### DIFF
--- a/lib/sonos/endpoint/a_v_transport.rb
+++ b/lib/sonos/endpoint/a_v_transport.rb
@@ -144,9 +144,11 @@ module Sonos::Endpoint::AVTransport
 
     # In order for the player to retrieve track duration, artist, album etc
     # we need to pass it some metadata ourselves.
-    didl_metadata = "&lt;DIDL-Lite xmlns:dc=&quot;http://purl.org/dc/elements/1.1/&quot; xmlns:upnp=&quot;urn:schemas-upnp-org:metadata-1-0/upnp/&quot; xmlns:r=&quot;urn:schemas-rinconnetworks-com:metadata-1-0/&quot; xmlns=&quot;urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/&quot;&gt;&lt;item id=&quot;#{rand(10000000..99999999)}spotify%3a#{opts[:type]}%3a#{opts[:id]}&quot; restricted=&quot;true&quot;&gt;&lt;dc:title&gt;&lt;/dc:title&gt;&lt;upnp:class&gt;object.item.audioItem.musicTrack&lt;/upnp:class&gt;&lt;desc id=&quot;cdudn&quot; nameSpace=&quot;urn:schemas-rinconnetworks-com:metadata-1-0/&quot;&gt;SA_RINCON2311_X_#Svc2311-0-Token&lt;/desc&gt;&lt;/item&gt;&lt;/DIDL-Lite&gt;"
+    didl_metadata = <<DIDL
+    lt;DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"&gt;&lt;item id="#{rand(10000000..19999999)}spotify%3a#{opts[:type]}%3a#{opts[:id]}" restricted="true"&gt;&lt;dc:title&gt;&lt;/dc:title&gt;&lt;upnp:class&gt;object.item.audioItem.musicTrack&lt;/upnp:class&gt;&lt;desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/"&gt;SA_RINCON2311_X_#Svc2311-0-Token&lt;/desc&gt;&lt;/item&gt;&lt;/DIDL-Lite&gt;
+DIDL
 
-    r_id = rand(10000000..99999999)
+    r_id = rand(10000000..19999999)
 
     case opts[:type]
     when /playlist/

--- a/lib/sonos/version.rb
+++ b/lib/sonos/version.rb
@@ -1,3 +1,3 @@
 module Sonos
-  VERSION = '0.3.6'
+  VERSION = '0.3.7'
 end


### PR DESCRIPTION
Only tested with tracks at the moment.

Replaced the DIDL metadata with the body from the latest Sonos app. Also had to narrow the random id range down to <20000000.