### PR TITLE
Switch & check for playbar TV input

### DIFF
--- a/lib/sonos/endpoint/device.rb
+++ b/lib/sonos/endpoint/device.rb
@@ -16,6 +16,10 @@ module Sonos::Endpoint::Device
     parse_response send_device_message('SetLEDState', enabled ? 'On' : 'Off')
   end
 
+  def get_zone_info
+    send_device_message('GetZoneInfo', '').body[:get_zone_info_response]
+  end
+
   # Create a stereo pair of two speakers.
   # This does not take into account which type of players support bonding.
   # Currently only S1/S3 (play:1/play:3) support this but future players may

--- a/lib/sonos/system.rb
+++ b/lib/sonos/system.rb
@@ -31,6 +31,10 @@ module Sonos
       end
     end
 
+    def inactive?
+      speakers.all? &:inactive?
+    end
+
     # Party Mode!  Join all speakers into a single group.
     def party_mode new_master = nil
       return nil unless speakers.length > 1


### PR DESCRIPTION
I have a playbar and wanted to be able to programmatically switch it to playing the TOSLINK optical input, and to test whether it was currently playing from same. With this change I can do this:

```
system = Sonos::System.new
playbar = system.find_speaker_by_name('Lounge')
playbar.tv
playbar.is_tv? # => true
```

and it becomes possible to reverse the Playbar's ungroup-on-autoplay, with an automatic re-grouping when idle:

```
system.party_mode if system.groups.count > 1 && system.inactive?
```
