### PR TITLE
Use Nokogiri that compatibles with ruby 2.0

### DIFF
--- a/sonos.gemspec
+++ b/sonos.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 1.9.2'
   gem.add_dependency 'savon', '~> 2.0'
-  gem.add_dependency 'nokogiri'
+  gem.add_dependency 'nokogiri', '~> 1.6.8'
   gem.add_dependency 'thor'
   gem.add_dependency 'httpclient'
   gem.add_dependency 'ssdp'


### PR DESCRIPTION
Since this gem works best in ruby 2.0, I assume (because the discovery is broken in ruby 2.1), let's use the `nokogiri` that is compatible with ruby 2.0.